### PR TITLE
Increase lmax to 15 in Figure 13

### DIFF
--- a/tex/figures/python/compare_to_batman_nonlinear.py
+++ b/tex/figures/python/compare_to_batman_nonlinear.py
@@ -137,7 +137,7 @@ a = ((P * 86400) ** 2 * (1.32712440018e20 * mstar) /
 inc = np.arccos(b0 / a) * 180 / np.pi
 
 # Get the polynomial coeffs for l = 6
-order = 6
+order = 15
 u, err = GetPolynomialCoeffs(c, order)
 print("Polynomial fit error: %.3e" % err)
 
@@ -258,6 +258,7 @@ axleg2.set_xlim(2, 3)
 leg = axleg2.legend(loc='center', labelspacing=1, frameon=False)
 leg.set_title('log error', prop={'weight': 'bold'})
 
-# Print average ratio
+# Print average time and error ratios
 print(np.nanmedian(agol_time / batman_time))
+print(err_agol / err_batman)
 fig.savefig("compare_to_batman_nonlinear.pdf", bbox_inches='tight')


### PR DESCRIPTION
I recommend increasing the order of the nonlinear fit from 6 to ~15 in Figure 13. This significantly reduces the error while not increasing the run time that much. With `l=15`, our run time is about 4x faster than batman and we get 7x smaller error. Also, the statement in the caption of Figure 9 isn't quite right, as the accuracy of the fit keeps increasing above `l=6` (although it's hard to see on a linear scale; it would be clearer if you plotted it in log space). Somewhere between `l=15` and `l=20` this turns over, however, since we hit the roundoff error noise floor.